### PR TITLE
PHR-links forced to alphabetical order

### DIFF
--- a/build/vue_template.html
+++ b/build/vue_template.html
@@ -604,7 +604,7 @@
                 return obj
               }
             }))
-            return filtered
+            return filtered.sort((a, b) => a.name < b.name ? - 1 : Number(a.name > b.name))
           }
         }
       })


### PR DESCRIPTION
PHR-links forced to alphabetical order ( helps to keep phr-model and phr-link treeviews in same order )